### PR TITLE
fix hell raven liquid speeds in 1.18

### DIFF
--- a/src/main/resources/data/touhouorigins/powers/born_in_flame.json
+++ b/src/main/resources/data/touhouorigins/powers/born_in_flame.json
@@ -39,10 +39,12 @@
     "frequency": 10
   },
   "lava_speed": {
-    "type": "apoli:modify_lava_speed",
+    "type": "apoli:attribute",
     "modifier": {
-      "operation": "addition",
-      "value": 0.4
+      "name": "Increased Lava Speed",
+      "attribute": "additionalentityattributes:lava_speed",
+      "value": 0.4,
+      "operation": "addition"
     }
   },
   "water_speed": {
@@ -56,5 +58,12 @@
     "type": "apoli:lava_vision",
     "s": 0,
     "v": 15
+  },
+  "lava_swimming": {
+    "type": "apoli:swimming",
+    "condition": {
+      "type": "apoli:submerged_in",
+      "fluid": "minecraft:lava"
+    }
   }
 }


### PR DESCRIPTION
the `modify_lava_speed` power modifies the water swim speed in this version for whatever reason, so swimming in water was very quick and lava speed was unaffected. lets modify the attribute directly instead.

i also added the ability to go into the swimming animation (which does give more speed) while in lava, feel free to remove that if you don't like the addition